### PR TITLE
Fix ChainId for BSC testnet

### DIFF
--- a/src/config/contracts/bsc-testnet.ts
+++ b/src/config/contracts/bsc-testnet.ts
@@ -15,8 +15,8 @@ class BinanceSmartChainTestnet implements IContractDefinition {
 
   constructor () {
     this.chainId = ChainId.BinanceSmartChainTestnet
-    this.chain = 'Binance Smart Chain Main Network'
-    this.rpcProvider = 'https://bsc-dataseed.binance.org/'
+    this.chain = 'Binance Smart Chain Test Network'
+    this.rpcProvider = 'https://data-seed-prebsc-1-s1.binance.org:8545/'
     this.store = '0x6e6b8163Ce003821925d706a181f09F22795B6E7'
 
     this.tokens = {

--- a/src/types/ChainId.ts
+++ b/src/types/ChainId.ts
@@ -1,7 +1,7 @@
 enum ChainId {
   Ethereum = 1,
   Ropsten = 3,
-  BinanceSmartChainTestnet = 56,
+  BinanceSmartChainTestnet = 97,
   Mumbai = 80001
 }
 


### PR DESCRIPTION
### Summary
- Fixed `ChainId` value for member `BinanceSmartChainTestnet`
- Fixed typos in RPC uri and name for BSC testnet